### PR TITLE
Update Capfile

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,6 +1,7 @@
 require "capistrano/setup"
 require "capistrano/deploy"
 require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
 require 'capistrano/rbenv'
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'


### PR DESCRIPTION
## what 
* $ bundle exec cap production deploy
[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git

#<Thread:0x0000558209462180@/home/ec2-user/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/sshkit-1.18.2/lib/sshkit/runners/parallel.rb:10 run> terminated with exception (report_on_exception is true):
というエラーが出たので言われた通りに追加